### PR TITLE
Change default iter count and create output folder

### DIFF
--- a/quads/cli.go
+++ b/quads/cli.go
@@ -20,7 +20,7 @@ type Flags struct {
 func initializeFlags() *Flags {
 	flags := Flags{
 		f:  flag.String("f", "", "Input image name"),
-		i:  flag.Int("i", 20, "Number of quad iterations to perform"),
+		i:  flag.Int("i", 200, "Number of quad iterations to perform"),
 		b:  flag.Bool("b", false, "Adds 1px black border to quads"),
 		bc: flag.String("bc", "0,0,0", "Border/ background color between quads"),
 		g:  flag.Bool("g", false, "Convert the intermediate images to a GIF"),

--- a/quads/main.go
+++ b/quads/main.go
@@ -4,7 +4,10 @@ package main
 import (
 	"container/heap"
 	"log"
+	"os"
 )
+
+const outputFolder string = "./out/"
 
 type Img struct {
 	hist   [][]int   //Histogram of image stored as [R, G, B]
@@ -23,6 +26,12 @@ func main() {
 	flags := initializeFlags()
 	if *flags.f == "" {
 		log.Fatal(" -f <input image> required")
+	}
+
+	if _, err := os.Stat(outputFolder); os.IsNotExist(err) {
+		if err := os.Mkdir(outputFolder, os.ModeDir); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	headNode, err := initialize(*flags.f)

--- a/quads/quads.go
+++ b/quads/quads.go
@@ -198,7 +198,7 @@ func saveImage(i *Img, in string, itr int, border bool, color bool, max int, col
 	}
 	num.WriteString(strconv.Itoa(itr))
 	n := concatName(in, num.String())
-	imaging.Save(fo, "./out/"+n)
+	imaging.Save(fo, outputFolder+n)
 
 	return nil
 }


### PR DESCRIPTION
As the documentation note, 200 iteration should be the default so I increased the default value from 20 to 200.

The output folder ``.out`` was required for the program to work but the folder wasn't being created if it was missing, so I added that.